### PR TITLE
Fix: Skip downloading videos that already exist

### DIFF
--- a/siq2/download_all.py
+++ b/siq2/download_all.py
@@ -63,19 +63,18 @@ def find_active_videos(ids):
             transcript_found = True
             
             temp_folder = tempfile.TemporaryDirectory()
-
-            # don't download if the trimmed video already exists
-            final_path = join(video_path, id + ".mp4")
-            if os.path.exists(final_path):
-                found_vids.append(id)
-                continue
-
-            # download full video from youtube if available
-            full_video = youtube_utils.download_video(id, temp_folder.name, False)
-            if full_video == None:
-                video_found = False
-                videos_not_found.append(id)
-                continue
+            trimmed_path = join(video_path, id + ".mp4")
+            
+            if os.path.exists(trimmed_path):
+                full_video = trimmed_path
+            else:
+                # Download full video from YouTube
+                full_video = youtube_utils.download_video(id, temp_folder.name, False)
+                if full_video is None:
+                    video_found = False
+                    videos_not_found.append(id)
+                    temp_folder.cleanup()
+                    continue
 
             # trim mp4
             if not os.path.exists(join(video_path, id + ".mp4")):

--- a/siq2/download_all.py
+++ b/siq2/download_all.py
@@ -64,6 +64,12 @@ def find_active_videos(ids):
             
             temp_folder = tempfile.TemporaryDirectory()
 
+            # don't download if the trimmed video already exists
+            final_path = join(video_path, id + ".mp4")
+            if os.path.exists(final_path):
+                found_vids.append(id)
+                continue
+
             # download full video from youtube if available
             full_video = youtube_utils.download_video(id, temp_folder.name, False)
             if full_video == None:


### PR DESCRIPTION
This pull request improves the download_all.py script by skipping video downloads if the trimmed video already exists in the siq2/video/ directory.

Currently, the script downloads every video to a temporary directory regardless of whether it has already been processed. This causes unnecessary bandwidth usage and time loss, especially for large-scale downloads or resuming interrupted sessions.